### PR TITLE
Using list api response as cache for each individual entity

### DIFF
--- a/src/libs/hooks/test/libs/Wrapper.tsx
+++ b/src/libs/hooks/test/libs/Wrapper.tsx
@@ -1,4 +1,19 @@
 import { SWRConfig } from "swr";
+export const createWrapper = (
+  cache: Map
+): React.FC<{ children: React.ReactNode }> => {
+  return (props) => (
+    <SWRConfig
+      value={{
+        // Clearing cache between cases
+        provider: () => cache,
+      }}
+    >
+      {props.children};
+    </SWRConfig>
+  );
+};
+
 export const Wrapper: React.FC<{ children: React.ReactNode }> = (props) => {
   return (
     <SWRConfig

--- a/src/libs/hooks/test/users.test.tsx
+++ b/src/libs/hooks/test/users.test.tsx
@@ -19,7 +19,7 @@ describe("libs/hooks/users", () => {
   });
 
   it("fetch a user", async () => {
-    const { result } = renderHook(() => useUser("100"), {
+    const { result } = renderHook(() => useUser(100), {
       wrapper: Wrapper,
     });
 
@@ -65,7 +65,7 @@ describe("libs/hooks/users", () => {
 
     expect(list.current.isLoading).toBeFalsy();
 
-    const { result: user } = renderHook(() => useUser("3"), {
+    const { result: user } = renderHook(() => useUser(3), {
       wrapper,
     });
 

--- a/src/libs/hooks/test/users.test.tsx
+++ b/src/libs/hooks/test/users.test.tsx
@@ -5,7 +5,7 @@ import { useUser, useUsers } from "../users";
 import { sleep } from "../../sleep";
 import { getUserHandler } from "./libs/getUserHandler";
 import { getMockUser } from "./libs/getMockUser";
-import { Wrapper } from "./libs/Wrapper";
+import { createWrapper, Wrapper } from "./libs/Wrapper";
 import { getUsersHandler } from "./libs/getUsersHandler";
 
 const mockServer = setupServer(getUserHandler(), getUsersHandler());
@@ -50,5 +50,25 @@ describe("libs/hooks/users", () => {
 
     expect(result.current.data?.list).toHaveLength(10);
     expect(result.current.isLoading).toBeFalsy();
+  });
+
+  it("cache", async () => {
+    const cache = new Map();
+    const wrapper = createWrapper(cache);
+    const { result: list } = renderHook(() => useUsers(), {
+      wrapper,
+    });
+
+    expect(list.current.isLoading).toBeTruthy();
+
+    await act(sleep);
+
+    expect(list.current.isLoading).toBeFalsy();
+
+    const { result: user } = renderHook(() => useUser("3"), {
+      wrapper,
+    });
+
+    expect(user.current.data).toBeDefined();
   });
 });

--- a/src/libs/hooks/users.tsx
+++ b/src/libs/hooks/users.tsx
@@ -7,7 +7,9 @@ const fetchUser = async (userId: string): Promise<User> => {
   const response = await fetch(`https://some.api.provider/api/user/${userId}`);
   return response.json() as Promise<User>;
 };
-export const useUser = (userId: string): ReturnType<typeof useSWR<User>> => {
+export const useUser = (
+  userId: User["id"]
+): ReturnType<typeof useSWR<User>> => {
   return useSWR<User>(
     ["/api/user/:userId", userId],
     async ([, userId]) => fetchUser(userId),


### PR DESCRIPTION
## Overview

- Wrapping `mutate` as a part of useUser module
- Making side effect inside of list api client